### PR TITLE
installation: fix invenio_access import

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,6 +45,7 @@ Invenio module that adds support for sending messages.
 - Marko Niinimaki <manzikki@gmail.com>
 - Nicholas Robinson <nicholas.robinson@cern.ch>
 - Raquel Jimenez Encinar <raquel.jimenez.encinar@cern.ch>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Samuele Kaplun <samuele.kaplun@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
 - Yoan Blanc <yoan.blanc@cern.ch>

--- a/invenio_messages/dblayer.py
+++ b/invenio_messages/dblayer.py
@@ -496,7 +496,7 @@ def check_quota(nb_messages):
     @return: a dictionary of users over-quota
     """
     from invenio.legacy.webuser import collect_user_info
-    from invenio.modules.access.control import acc_is_user_in_role, acc_get_role_id
+    from invenio_access.control import acc_is_user_in_role, acc_get_role_id
     no_quota_role_ids = [acc_get_role_id(
         role) for role in CFG_WEBMESSAGE_ROLES_WITHOUT_QUOTA]
     res = {}

--- a/invenio_messages/query.py
+++ b/invenio_messages/query.py
@@ -457,7 +457,7 @@ def check_quota(nb_messages):
     @return: a dictionary of users over-quota
     """
     from invenio.legacy.webuser import collect_user_info
-    from invenio.modules.access.control import acc_is_user_in_role, acc_get_role_id
+    from invenio_access.control import acc_is_user_in_role, acc_get_role_id
     no_quota_role_ids = [acc_get_role_id(
         role) for role in CFG_WEBMESSAGE_ROLES_WITHOUT_QUOTA]
     res = {}

--- a/invenio_messages/utils.py
+++ b/invenio_messages/utils.py
@@ -21,7 +21,7 @@
 
 from invenio.base.globals import cfg
 from invenio.ext.login import UserInfo
-from invenio.modules.access.control import acc_get_role_id, acc_is_user_in_role
+from invenio_access.control import acc_get_role_id, acc_is_user_in_role
 
 
 def is_no_quota_user(uid):

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-access>=0.1.0',
     'invenio-accounts>=0.1.0',
     'invenio-groups>=0.1.0',
 ]
@@ -49,6 +50,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
- Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
