### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_messages/bundles.py
+++ b/invenio_messages/bundles.py
@@ -21,9 +21,9 @@
 
 from __future__ import unicode_literals
 
-from invenio.base.bundles import invenio as _i
-from invenio.base.bundles import jquery as _j
-from invenio.base.bundles import styles as _styles
+from invenio_base.bundles import invenio as _i
+from invenio_base.bundles import jquery as _j
+from invenio_base.bundles import styles as _styles
 from invenio.ext.assets import Bundle, RequireJSFilter
 
 _styles.contents.append(

--- a/invenio_messages/forms.py
+++ b/invenio_messages/forms.py
@@ -27,8 +27,8 @@ from six import iteritems
 from wtforms import DateTimeField, RadioField, StringField, TextAreaField, \
     validators
 
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio.ext.sqlalchemy import db
 from invenio.utils.forms import DateTimePickerWidget, FilterForm, \
     FilterStringField, InvenioBaseForm

--- a/invenio_messages/models.py
+++ b/invenio_messages/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2011, 2012 CERN.
+# Copyright (C) 2011, 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -30,7 +30,7 @@ from invenio_accounts.models import User
 from invenio_groups.models import Group
 from sqlalchemy.ext.associationproxy import association_proxy
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.config import CFG_WEBCOMMENT_ALERT_ENGINE_EMAIL
 from invenio.ext.sqlalchemy import db
 from invenio.utils.date import datetext_format

--- a/invenio_messages/user_settings.py
+++ b/invenio_messages/user_settings.py
@@ -22,7 +22,7 @@
 from flask import current_app, url_for
 from flask_login import current_user
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.ext.sqlalchemy import db
 from invenio.ext.template import render_template_to_string
 from invenio.modules.dashboard.settings import Settings, UserSettingsStorage

--- a/invenio_messages/utils.py
+++ b/invenio_messages/utils.py
@@ -19,7 +19,7 @@
 
 """Utility functions for message module."""
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.login import UserInfo
 from invenio_access.control import acc_get_role_id, acc_is_user_in_role
 

--- a/invenio_messages/views.py
+++ b/invenio_messages/views.py
@@ -27,10 +27,10 @@ from flask_login import current_user, login_required
 from flask_menu import register_menu
 from sqlalchemy.sql import operators
 
-from invenio.base.decorators import filtered_by, sorted_by, templated, \
+from invenio_base.decorators import filtered_by, sorted_by, templated, \
     wash_arguments
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio.ext.principal import permission_required
 from invenio.ext.sqlalchemy import db
 from invenio.ext.template import render_template_to_string

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,11 +21,8 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-groups.git#egg=invenio-groups

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'invenio-access>=0.1.0',
     'invenio-accounts>=0.1.0',
+    'invenio-base>=0.2.1',
     'invenio-groups>=0.1.0',
 ]
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2009, 2010, 2011, 2013 CERN.
+# Copyright (C) 2009, 2010, 2011, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -23,7 +23,7 @@ __revision__ = \
     "$Id$"
 
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
 webmessage_mailutils = lazy_import('invenio.utils.mail')
 


### PR DESCRIPTION
- FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
